### PR TITLE
Update RcppArmadilloForward.h location

### DIFF
--- a/src/nsoptim/armadillo_forward.hpp
+++ b/src/nsoptim/armadillo_forward.hpp
@@ -19,7 +19,7 @@
 
 #ifdef HAVE_RCPP
 // For RCPP
-# include <RcppArmadilloForward.h>
+# include <RcppArmadillo/interface/RcppArmadilloForward.h>
 #else
 // For stand-alone
 # include <armadillo>


### PR DESCRIPTION
As detailed in [issue #400 in the RcppArmadillo repo](https://github.com/RcppCore/RcppArmadillo/issues/400) we would like to (re)move some internal header files. `pense` is one of very few packages directly accessing one of these, and this PR suggests a simple way to at least access the new location of RcppArmadilloForward.h. (It would be preferable to only include RcppArmadillo.h.  I did not see an immediate way but I didn't look hard or long and could try to help some more if you are interested too.)

With this PR, the package still builds and checks cleanly for me. It would be lovely if you could consider this, possible merge this and get an updated version to CRAN in the next few months. If you do so, please leave a comment to at the linked issue so that we can keep track. Thanks for your consideration, and please don't hesitate to ask if anything seems unclear.